### PR TITLE
Fix bug on `LinearGradient`'s stops on Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class ContentLoader extends Component {
                 '-2', '-1.5', '-1'
             ],
             offsets: [
-                '0', '0', '0'
+                '0.0001', '0.0002', '0.0003' // Avoid duplicate value cause error in Android
             ],
             frequence: props.duration / 2
         }
@@ -73,7 +73,14 @@ export default class ContentLoader extends Component {
             offsetValues[0] = this.offsetValueBound(newState.offsetValues[0]);
             offsetValues[1] = this.offsetValueBound(newState.offsetValues[1]);
             offsetValues[2] = this.offsetValueBound(newState.offsetValues[2]);
-            this.setState({offsets: offsetValues});
+
+            // Make sure at least two offsets is different
+            // original fix from: https://github.com/virusvn/react-native-svg-animated-linear-gradient/commit/b9558aab3bbd8f5be50204dd5cb67c9348c60fb9
+            if (offsetValues[0] !== offsetValues[1] ||
+                offsetValues[0] !==  offsetValues[2] ||
+                offsetValues[1] !== offsetValues[2]) {
+                this.setState({offsets: offsetValues});
+            }
             if (t < 1) {
                 requestAnimationFrame(this._animation);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export default class ContentLoader extends Component {
             frequence: props.duration / 2
         }
         this._animate = new Animated.Value(0)
+        this._isMounted =  false
         this.loopAnimation = this
             .loopAnimation
             .bind(this)
@@ -48,11 +49,21 @@ export default class ContentLoader extends Component {
         }
         return x
     }
+
     componentDidMount(props) {
+        this._isMounted = true
         this.loopAnimation()
     }
 
+    componentWillUnmount() {
+        this._isMounted = false
+    }
+
     loopAnimation() {
+
+        if (!this._isMounted) {
+            return;
+        }
 
         // setup interpolate
         let interpolator = interpolate(this.state, {
@@ -62,6 +73,10 @@ export default class ContentLoader extends Component {
         // start animation
         let start = Date.now();
         this._animation = () => {
+            if (!this._isMounted) {
+                return;
+            }
+
             const now = Date.now();
             let t = (now - start) / this.props.duration;
             if (t > 1) {


### PR DESCRIPTION
This patch fixes an issue reported on `react-native-community/react-native-svg`'s
repository that made `LinearGradient` throw an error when it
has two or more `Stop` with the same offset.

ISSUE=https://github.com/react-native-community/react-native-svg/issues/385